### PR TITLE
Added ability to send named events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ var app = express()
 app.get('/events', sse, function (req, res) {
   res.json("this is an event");
   res.json({here: "is", another: "event"});
+  res.json({here: "is a named event", to: "listen with addEventListener('example', function(){})"}, "example");
 });
 ```

--- a/index.js
+++ b/index.js
@@ -7,8 +7,11 @@ module.exports = function () {
     resp.setHeader('Cache-Control', 'no-cache');
     resp.setHeader('Connection', 'keep-alive');
     message_count = 0;
-    resp.json = function(obj){
+    resp.json = function(obj, type){
       resp.write("id: " + message_count + "\n");
+      if('string' === typeof type) {
+        resp.write("event: " + type + "\n");
+      }
       resp.write("data: " + JSON.stringify(obj) + "\n\n");
       message_count += 1;
     };

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ app.get('/events', sse, function (req, res) {
   res.json("this is an event");
   setTimeout(function() {
     res.json({here: "is", another: "event"});
+    res.json({here: "is a named event", to: "listen with addEventListener('example', function(){})"}, "example");
   }, 100);
 });
 
@@ -37,8 +38,18 @@ server.listen(0, 'localhost', function() {
       assert(msg.here === "is");
       assert(msg.another === "event");
     },
+    function (msg) {
+      assert(msg.here === "is a named event");
+      assert(msg.to === "listen with addEventListener('example', function(){})");
+    }
   ];
   source.onmessage = function(e) {
+    var validate;
+    validate = message_validators.shift();
+    validate(JSON.parse(e.data));
+    process.stdout.write('.');
+  };
+  source.addEventListener("example", function(e) {
     var validate;
     validate = message_validators.shift();
     validate(JSON.parse(e.data));
@@ -48,5 +59,5 @@ server.listen(0, 'localhost', function() {
       source.close();
       server.close();
     }
-  };
-})
+  });
+});


### PR DESCRIPTION
If event type is specified, an event will be dispatched on the browser to the listener for the specified event name.
The web site would use addEventListener() to listen for named events.
The onmessage handler is called if no event name is specified for a message.

See https://developer.mozilla.org/en-US/docs/Server-sent_events/Using_server-sent_events#Fields
